### PR TITLE
refactor!: simplify `Repeat` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,5 @@ pub trait Repeat {
 
     fn previous_event(&self, instant: DateTime) -> Option<DateTime>;
 
-    fn is_aligned_to_series(&self, instant: DateTime, bounds: &Range<DateTime>) -> bool;
-
-    fn align_to_series(&self, instant: DateTime, bounds: &Range<DateTime>) -> Option<DateTime>;
+    fn closest_event(&self, instant: DateTime, bounds: &Range<DateTime>) -> Option<DateTime>;
 }

--- a/src/repeat.rs
+++ b/src/repeat.rs
@@ -78,12 +78,8 @@ impl Repeat for Interval {
         instant.checked_sub(self.0).ok()
     }
 
-    fn is_aligned_to_series(&self, instant: DateTime, bounds: &Range<DateTime>) -> bool {
-        is_aligned_to_series(instant, bounds, self.0)
-    }
-
-    fn align_to_series(&self, instant: DateTime, bounds: &Range<DateTime>) -> Option<DateTime> {
-        align_to_series(instant, bounds, self.0)
+    fn closest_event(&self, instant: DateTime, bounds: &Range<DateTime>) -> Option<DateTime> {
+        closest_event(instant, bounds, self.0)
     }
 }
 
@@ -204,62 +200,54 @@ impl Daily {
 impl Repeat for Daily {
     fn next_event(&self, instant: DateTime) -> Option<DateTime> {
         if self.at.is_empty() {
-            self.interval.next_event(instant)
-        } else {
-            for time in &self.at {
-                let date = instant.with().time(*time).build().ok()?;
-
-                if date > instant {
-                    return Some(date);
-                }
-            }
-
-            let next = self.interval.next_event(instant)?;
-            next.with().time(self.at[0]).build().ok()
+            return self.interval.next_event(instant);
         }
+
+        for time in &self.at {
+            let date = instant.with().time(*time).build().ok()?;
+
+            if date > instant {
+                return Some(date);
+            }
+        }
+
+        let next = self.interval.next_event(instant)?;
+        next.with().time(self.at[0]).build().ok()
     }
 
     fn previous_event(&self, instant: DateTime) -> Option<DateTime> {
         if self.at.is_empty() {
-            self.interval.previous_event(instant)
-        } else {
-            for time in self.at.iter().rev() {
-                let date = instant.with().time(*time).build().ok()?;
+            return self.interval.previous_event(instant);
+        }
 
-                if date < instant {
-                    return Some(date);
-                }
+        for time in self.at.iter().rev() {
+            let date = instant.with().time(*time).build().ok()?;
+
+            if date < instant {
+                return Some(date);
             }
-
-            let previous = self.interval.previous_event(instant)?;
-            previous.with().time(*self.at.last().unwrap()).build().ok()
         }
+
+        let previous = self.interval.previous_event(instant)?;
+        previous
+            .with()
+            .time(self.at[self.at.len() - 1])
+            .build()
+            .ok()
     }
 
-    fn is_aligned_to_series(&self, instant: DateTime, bounds: &Range<DateTime>) -> bool {
+    fn closest_event(&self, instant: DateTime, bounds: &Range<DateTime>) -> Option<DateTime> {
         if self.at.is_empty() {
-            self.interval.is_aligned_to_series(instant, bounds)
-        } else {
-            instant
-                .checked_sub(1.minute())
-                .ok()
-                .and_then(|start| self.next_event(start))
-                .is_some_and(|date| date == instant)
+            return self.interval.closest_event(instant, bounds);
         }
-    }
 
-    fn align_to_series(&self, instant: DateTime, bounds: &Range<DateTime>) -> Option<DateTime> {
-        if self.at.is_empty() {
-            self.interval.align_to_series(instant, bounds)
-        } else {
-            let aligned = self.interval.align_to_series(instant, bounds)?;
+        let closest = self.interval.closest_event(instant, bounds)?;
 
-            self.at
-                .iter()
-                .filter_map(|time| aligned.with().time(*time).build().ok())
-                .filter(|date| bounds.contains(date))
-                .min_by_key(|date| date.duration_since(instant).abs())
-        }
+        self.at
+            .iter()
+            .filter_map(|time| closest.with().time(*time).build().ok())
+            .filter(|date| bounds.contains(date))
+            .min_by_key(|date| date.duration_since(instant).abs())
     }
 }
 
@@ -390,23 +378,12 @@ pub fn yearly<I: ToSpan>(interval: I) -> Interval {
     Interval::new(interval.years())
 }
 
-fn is_aligned_to_series(instant: DateTime, bounds: &Range<DateTime>, interval: Span) -> bool {
-    const ALLOWED_INTERVAL_ERROR: f64 = 0.000_001;
-
-    intervals_until(bounds.start, instant, interval)
-        .is_some_and(|intervals| intervals.fract() < ALLOWED_INTERVAL_ERROR)
-}
-
-fn align_to_series(
-    instant: DateTime,
-    bounds: &Range<DateTime>,
-    interval: Span,
-) -> Option<DateTime> {
-    let intervals = get_alignment_intervals(instant, bounds, interval)?;
+fn closest_event(instant: DateTime, bounds: &Range<DateTime>, interval: Span) -> Option<DateTime> {
+    let intervals = intervals_until_closest_event(instant, bounds, interval)?;
     bounds.start.checked_add(intervals * interval).ok()
 }
 
-fn get_alignment_intervals(
+fn intervals_until_closest_event(
     instant: DateTime,
     bounds: &Range<DateTime>,
     interval: Span,
@@ -416,17 +393,17 @@ fn get_alignment_intervals(
     }
 
     let end = instant.min(bounds.end);
+    let intervals = intervals_until(bounds.start, end, interval)?;
+    let mut intervals_rounded = intervals.round();
 
-    let mut intervals = intervals_until(bounds.start, end, interval)?;
-
-    if end == bounds.end && intervals.round() >= intervals {
+    if end == bounds.end && intervals_rounded >= intervals {
         // The series would hit the end bound exactly or due to rounding up. We need to substract
         // an interval because the series end bound is exclusive.
-        intervals -= 1.0;
+        intervals_rounded -= 1.0;
     }
 
     #[allow(clippy::cast_possible_truncation)]
-    Some(intervals.round() as i64)
+    Some(intervals_rounded as i64)
 }
 
 fn intervals_until(start: DateTime, end: DateTime, interval: Span) -> Option<f64> {
@@ -449,53 +426,23 @@ mod tests {
     use jiff::civil::date;
 
     #[test]
-    fn test_is_aligned_to_series() {
-        let start = date(2025, 1, 1).at(0, 0, 0, 0);
-        let bounds = start..DateTime::MAX;
-
-        assert!(!is_aligned_to_series(
-            date(2025, 1, 1).at(0, 30, 0, 0),
-            &bounds,
-            1.hour()
-        ));
-        assert!(is_aligned_to_series(
-            date(2025, 1, 1).at(0, 0, 0, 0),
-            &bounds,
-            1.hour()
-        ));
-        assert!(is_aligned_to_series(
-            date(2025, 1, 1).at(1, 0, 0, 0),
-            &bounds,
-            1.hour()
-        ));
-
-        let bounds = start..DateTime::MAX;
-
-        assert!(is_aligned_to_series(
-            date(9999, 12, 31).at(22, 0, 0, 0),
-            &bounds,
-            2.hour()
-        ),);
-    }
-
-    #[test]
-    fn test_align_to_series() {
+    fn test_closest_event() {
         let start = date(2025, 1, 1).at(0, 0, 0, 0);
         let end = date(2025, 1, 3).at(0, 0, 0, 0);
         let bounds = start..end;
 
         assert_eq!(
-            align_to_series(date(2025, 1, 1).at(0, 0, 0, 0), &bounds, 1.hour()),
+            closest_event(date(2025, 1, 1).at(0, 0, 0, 0), &bounds, 1.hour()),
             Some(date(2025, 1, 1).at(0, 0, 0, 0))
         );
 
         assert_eq!(
-            align_to_series(date(2025, 1, 1).at(0, 30, 0, 0), &bounds, 1.hour()),
+            closest_event(date(2025, 1, 1).at(0, 30, 0, 0), &bounds, 1.hour()),
             Some(date(2025, 1, 1).at(1, 0, 0, 0))
         );
 
         assert_eq!(
-            align_to_series(
+            closest_event(
                 date(2025, 1, 1)
                     .at(0, 30, 0, 0)
                     .checked_sub(1.nanosecond())
@@ -507,24 +454,24 @@ mod tests {
         );
 
         assert_eq!(
-            align_to_series(date(2024, 12, 31).at(0, 30, 0, 0), &bounds, 1.hour()),
+            closest_event(date(2024, 12, 31).at(0, 30, 0, 0), &bounds, 1.hour()),
             Some(date(2025, 1, 1).at(0, 0, 0, 0))
         );
 
         assert_eq!(
-            align_to_series(date(2025, 1, 3).at(0, 0, 0, 0), &bounds, 1.hour()),
+            closest_event(date(2025, 1, 3).at(0, 0, 0, 0), &bounds, 1.hour()),
             Some(date(2025, 1, 2).at(23, 0, 0, 0))
         );
 
         assert_eq!(
-            align_to_series(date(2025, 2, 10).at(0, 30, 0, 0), &bounds, 1.hour()),
+            closest_event(date(2025, 2, 10).at(0, 30, 0, 0), &bounds, 1.hour()),
             Some(date(2025, 1, 2).at(23, 0, 0, 0))
         );
 
         let bounds = start..DateTime::MAX;
 
         assert_eq!(
-            align_to_series(DateTime::MAX, &bounds, 2.hours()),
+            closest_event(DateTime::MAX, &bounds, 2.hours()),
             Some(date(9999, 12, 31).at(22, 0, 0, 0))
         );
     }


### PR DESCRIPTION
Renames `align_to_series` to `closest_event` to make it clearer what it does. Also removes `is_aligned_to_series` because it's not necessary.

Does some other refactorings along the way.