### PR TITLE
feat: better errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,54 +1,208 @@
+use alloc::boxed::Box;
+use core::{error, fmt, ops::Range};
+use jiff::{Error as JiffError, civil::DateTime};
+
+/// A macro for conveniently creating adhoc error values.
+///
+/// This accepts the same arguments as the `format!` macro.
+macro_rules! err {
+    ($($tt:tt)*) => {{
+        crate::error::Error::adhoc(format_args!($($tt)*))
+    }}
+}
+
+pub(crate) use err;
+
 /// Error type returned by all fallible operations within this crate.
 ///
 /// This type is opaque for the time being and currently does not provide any introspection
-/// capabilities apart from its [`Debug`][core::fmt::Debug] and [`Display`][core::fmt::Display]
+/// capabilities apart from its [`Debug`][fmt::Debug] and [`Display`][fmt::Display]
 /// implementations.
 #[derive(Clone)]
 pub struct Error {
-    kind: ErrorKind,
+    kind: Box<ErrorKind>,
 }
 
-impl core::fmt::Display for Error {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match &self.kind {
-            ErrorKind::InvalidBounds => f.write_str("end must be greater than start"),
-            ErrorKind::InvalidEventDuration => {
-                f.write_str("event duration must be positive or zero")
-            }
-            ErrorKind::InvalidInterval => {
-                f.write_str("interval must be positive, non-zero and not include sub-second units")
-            }
-            ErrorKind::Jiff(err) => err.fmt(f),
-            ErrorKind::OutOfBounds => f.write_str("value out of bounds"),
-        }
+impl Error {
+    /// Creates a new "ad hoc" error value.
+    ///
+    /// An ad hoc error value is just an opaque string.
+    #[inline(never)]
+    #[cold]
+    pub(crate) fn adhoc(message: impl fmt::Display) -> Error {
+        Error::from(ErrorKind::Adhoc(AdhocError::from_display(message)))
     }
-}
 
-impl core::fmt::Debug for Error {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Error").field(&self.kind).finish()
+    /// Creates a new error indicating that a `given` value is out of the specified `min..=max`
+    /// range.
+    #[inline(never)]
+    #[cold]
+    pub(crate) fn range(given: impl Into<i64>, min: impl Into<i64>, max: impl Into<i64>) -> Error {
+        Error::from(ErrorKind::Range(RangeError::new(given, min, max)))
     }
-}
 
-impl core::error::Error for Error {}
+    /// Creates a new error indicating that the end of a datetime range is not strictly greater
+    /// than its start.
+    #[inline(never)]
+    #[cold]
+    pub(crate) fn datetime_range(what: &'static str, range: Range<DateTime>) -> Error {
+        Error::from(ErrorKind::DateTimeRange(DateTimeRangeError::new(
+            what, range,
+        )))
+    }
 
-impl From<jiff::Error> for Error {
-    fn from(err: jiff::Error) -> Self {
+    /// Creates a new error from a `jiff` error.
+    #[inline(never)]
+    #[cold]
+    pub(crate) fn jiff(err: JiffError) -> Error {
         Error::from(ErrorKind::Jiff(err))
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.kind, f)
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Error").field("kind", &self.kind).finish()
+    }
+}
+
+impl error::Error for Error {}
+
+impl From<JiffError> for Error {
+    fn from(err: JiffError) -> Self {
+        Error::jiff(err)
     }
 }
 
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Self {
-        Error { kind }
+        Error {
+            kind: Box::new(kind),
+        }
     }
 }
 
+/// The underlying kind of [`Error`].
 #[derive(Clone, Debug)]
-pub(crate) enum ErrorKind {
-    InvalidEventDuration,
-    InvalidInterval,
-    InvalidBounds,
-    Jiff(jiff::Error),
-    OutOfBounds,
+enum ErrorKind {
+    /// An ad hoc error that is constructed from anything that implements the `core::fmt::Display`
+    /// trait.
+    Adhoc(AdhocError),
+    /// An error that occurs when a number is not within its allowed range.
+    Range(RangeError),
+    /// Creates a new error indicating that the end of a datetime range is not strictly greater
+    /// than its start.
+    DateTimeRange(DateTimeRangeError),
+    /// An error produced by fallible operations on `jiff` types.
+    Jiff(JiffError),
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ErrorKind::Adhoc(ref adhoc) => fmt::Display::fmt(adhoc, f),
+            ErrorKind::Range(ref range) => fmt::Display::fmt(range, f),
+            ErrorKind::DateTimeRange(ref range) => fmt::Display::fmt(range, f),
+            ErrorKind::Jiff(ref jiff) => fmt::Display::fmt(jiff, f),
+        }
+    }
+}
+
+/// A generic error message.
+#[derive(Clone)]
+struct AdhocError {
+    message: Box<str>,
+}
+
+impl AdhocError {
+    /// Creates a new "ad hoc" error value.
+    ///
+    /// An ad hoc error value is just an opaque string.
+    fn from_display(message: impl fmt::Display) -> AdhocError {
+        use alloc::string::ToString;
+        AdhocError {
+            message: message.to_string().into_boxed_str(),
+        }
+    }
+}
+
+impl error::Error for AdhocError {}
+
+impl fmt::Display for AdhocError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.message, f)
+    }
+}
+
+impl fmt::Debug for AdhocError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.message, f)
+    }
+}
+
+/// An error that occurs when an input value is out of bounds.
+#[derive(Debug, Clone)]
+struct RangeError {
+    given: i64,
+    min: i64,
+    max: i64,
+}
+
+impl RangeError {
+    /// Creates a new error indicating that a `given` value is out of the specified `min..=max`
+    /// range.
+    fn new(given: impl Into<i64>, min: impl Into<i64>, max: impl Into<i64>) -> RangeError {
+        RangeError {
+            given: given.into(),
+            min: min.into(),
+            max: max.into(),
+        }
+    }
+}
+
+impl error::Error for RangeError {}
+
+impl fmt::Display for RangeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let RangeError { given, min, max } = *self;
+        write!(
+            f,
+            "parameter with value {given} \
+                 is not in the required range of {min}..={max}",
+        )
+    }
+}
+
+/// An error that occurs when the end of a datetime range is not strictly greater than its start.
+#[derive(Debug, Clone)]
+struct DateTimeRangeError {
+    what: &'static str,
+    range: Range<DateTime>,
+}
+
+impl DateTimeRangeError {
+    /// Creates a new error indicating that the end of a datetime range is not strictly greater
+    /// than its start.
+    fn new(what: &'static str, range: Range<DateTime>) -> DateTimeRangeError {
+        DateTimeRangeError { what, range }
+    }
+}
+
+impl error::Error for DateTimeRangeError {}
+
+impl fmt::Display for DateTimeRangeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{what} end must be greater than start but got {what} range {start}..{end}",
+            what = self.what,
+            start = self.range.start,
+            end = self.range.end
+        )
+    }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,4 @@
-use crate::{Error, error::ErrorKind};
+use crate::error::Error;
 use core::fmt;
 use jiff::{Span, civil::DateTime};
 
@@ -42,6 +42,7 @@ impl Event {
     /// let start = date(2025, 1, 1).at(0, 0, 0, 0);
     /// let event = Event::at(start);
     /// ```
+    #[inline]
     pub fn at(instant: DateTime) -> Event {
         Event {
             start: instant,
@@ -68,13 +69,20 @@ impl Event {
     /// ```
     pub fn new(start: DateTime, end: DateTime) -> Result<Event, Error> {
         if start >= end {
-            return Err(Error::from(ErrorKind::InvalidBounds));
+            return Err(Error::datetime_range("event", start..end));
         }
 
-        Ok(Event {
+        Ok(Event::new_unchecked(start, end))
+    }
+
+    /// Creates a new `Event` which spans from a `start` (inclusive) to an `end` (exclusive)
+    /// without checking that `end` is strictly greater than `start`.
+    #[inline]
+    pub(crate) fn new_unchecked(start: DateTime, end: DateTime) -> Event {
+        Event {
             start,
             end: Some(end),
-        })
+        }
     }
 
     /// Returns the `DateTime` at which the event starts.

--- a/src/pattern/daily.rs
+++ b/src/pattern/daily.rs
@@ -26,7 +26,7 @@ pub struct Daily {
 impl Daily {
     /// Creates a new `Daily` from an interval of days.
     ///
-    /// For a fallible alternative see [`Daily::try_new`].
+    /// The fallible version of this method is [`Daily::try_new`].
     ///
     /// # Panics
     ///
@@ -48,7 +48,7 @@ impl Daily {
 
     /// Creates a new `Daily` from an interval of days.
     ///
-    /// For an infallible alternative that panics on invalid spans instead see [`Daily::new`].
+    /// The packicking version of this method is [`Daily::new`].
     ///
     /// # Errors
     ///

--- a/src/pattern/interval.rs
+++ b/src/pattern/interval.rs
@@ -1,5 +1,9 @@
 use super::utils::{intervals_in_range_until, is_interval_boundary};
-use crate::{Error, Pattern, error::ErrorKind, private};
+use crate::{
+    Pattern,
+    error::{Error, err},
+    private,
+};
 use core::ops::Range;
 use jiff::{Span, civil::DateTime};
 
@@ -21,7 +25,7 @@ pub struct Interval {
 impl Interval {
     /// Creates a new `Interval` from a `Span`.
     ///
-    /// For a fallible alternative see [`Interval::try_new`].
+    /// The fallible version of this method is [`Interval::try_new`].
     ///
     /// # Panics
     ///
@@ -35,17 +39,14 @@ impl Interval {
     ///
     /// let every_two_hours = Interval::new(2.hours());
     /// ```
+    #[inline]
     pub fn new(span: Span) -> Interval {
-        assert!(
-            Interval::validate(span),
-            "interval must be positive, non-zero and not include sub-second units"
-        );
-        Interval { span }
+        Interval::try_new(span).expect("invalid interval span")
     }
 
     /// Creates a new `Interval` from a `Span`.
     ///
-    /// For an infallible alternative that panics on invalid spans instead see [`Interval::new`].
+    /// The packicking version of this method is [`Interval::new`].
     ///
     /// # Errors
     ///
@@ -65,7 +66,9 @@ impl Interval {
     /// ```
     pub fn try_new(span: Span) -> Result<Interval, Error> {
         if !Interval::validate(span) {
-            return Err(Error::from(ErrorKind::InvalidInterval));
+            return Err(err!(
+                "interval must be positive, non-zero and must not include sub-second units but got {span}"
+            ));
         }
 
         Ok(Interval { span })

--- a/src/pattern/ranged.rs
+++ b/src/pattern/ranged.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, ErrorKind};
+use crate::error::Error;
 use alloc::collections::btree_set::{self, BTreeSet};
 use core::ops::RangeInclusive;
 
@@ -30,7 +30,7 @@ impl<const MIN: i8, const MAX: i8> RangedI8Set<MIN, MAX> {
         if Self::is_within_bounds(value) {
             Ok(self.0.insert(value))
         } else {
-            Err(Error::from(ErrorKind::OutOfBounds))
+            Err(Error::range(value, Self::MIN, Self::MAX))
         }
     }
 
@@ -72,7 +72,7 @@ impl<const MIN: i16, const MAX: i16> RangedI16Set<MIN, MAX> {
         if Self::is_within_bounds(value) {
             Ok(self.0.insert(value))
         } else {
-            Err(Error::from(ErrorKind::OutOfBounds))
+            Err(Error::range(value, Self::MIN, Self::MAX))
         }
     }
 

--- a/tests/errors_test.rs
+++ b/tests/errors_test.rs
@@ -1,0 +1,70 @@
+use jiff::{ToSpan, civil::date};
+use recurring::{
+    Event, Series,
+    pattern::{Cron, Interval, daily},
+};
+
+macro_rules! assert_err {
+    ($expr:expr, $msg:literal $(,)?) => {
+        assert_eq!(($expr).unwrap_err().to_string(), $msg);
+    };
+}
+
+#[test]
+fn event_errors() {
+    let start = date(2025, 1, 1).at(0, 0, 0, 0);
+
+    assert_err!(
+        Event::new(start, start),
+        "event end must be greater than start but got event range 2025-01-01T00:00:00..2025-01-01T00:00:00",
+    );
+}
+
+#[test]
+fn series_errors() {
+    let start = date(2025, 1, 1).at(0, 0, 0, 0);
+
+    assert_err!(
+        Series::try_new(start..start, daily(1)),
+        "series end must be greater than start but got series range 2025-01-01T00:00:00..2025-01-01T00:00:00",
+    );
+
+    assert_err!(
+        Series::new(start.., daily(1))
+            .with()
+            .event_duration(-1.second())
+            .build(),
+        "event duration must be positive or zero but got -PT1S",
+    );
+
+    assert_err!(
+        Series::new(start.., daily(1)).with().end(start).build(),
+        "series end must be greater than start but got series range 2025-01-01T00:00:00..2025-01-01T00:00:00",
+    );
+}
+
+#[test]
+fn interval_errors() {
+    assert_err!(
+        Interval::try_new(0.seconds()),
+        "interval must be positive, non-zero and must not include sub-second units but got PT0S",
+    );
+
+    assert_err!(
+        Interval::try_new(1.second().nanoseconds(10)),
+        "interval must be positive, non-zero and must not include sub-second units but got PT1.00000001S",
+    );
+}
+
+#[test]
+fn cron_errors() {
+    assert_err!(
+        Cron::new().try_second(-10),
+        "parameter with value -10 is not in the required range of 0..=59",
+    );
+
+    assert_err!(
+        Cron::new().try_years([2025, 10000]),
+        "parameter with value 10000 is not in the required range of -9999..=9999",
+    );
+}


### PR DESCRIPTION
This improves error messages and also refactors the `Error` type to design that closely mirrors what `jiff::Error` does.