### PR TITLE
fix!: remove `Daily::at_times`

### DIFF
--- a/tests/daily_test.rs
+++ b/tests/daily_test.rs
@@ -1,0 +1,190 @@
+use jiff::ToSpan;
+use jiff::civil::{DateTime, date, time};
+use recurring::Pattern;
+use recurring::pattern::Daily;
+
+#[test]
+fn daily_next_after() {
+    let start = date(2025, 1, 1).at(0, 0, 0, 0);
+    let end = date(2025, 2, 1).at(0, 0, 0, 0);
+    let range = start..end;
+    let daily = Daily::new(2);
+    assert_eq!(
+        daily.next_after(DateTime::MIN, &range),
+        Some(date(2025, 1, 1).at(0, 0, 0, 0))
+    );
+    assert_eq!(
+        daily.next_after(range.start.checked_sub(1.nanosecond()).unwrap(), &range),
+        Some(date(2025, 1, 1).at(0, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.next_after(range.start, &range),
+        Some(date(2025, 1, 3).at(0, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.next_after(date(2025, 1, 1).at(0, 30, 0, 0), &range),
+        Some(date(2025, 1, 3).at(0, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.next_after(range.end - 1.day().nanoseconds(1), &range),
+        Some(date(2025, 1, 31).at(0, 0, 0, 0))
+    );
+    assert_eq!(daily.next_after(range.end - 1.day(), &range), None,);
+    assert_eq!(daily.next_after(range.end, &range), None);
+    assert_eq!(daily.next_after(DateTime::MAX, &range), None);
+}
+
+#[test]
+fn daily_at_next_after() {
+    let start = date(2025, 1, 1).at(0, 0, 0, 0);
+    let end = date(2025, 2, 1).at(0, 0, 0, 0);
+    let range = start..end;
+    let daily = Daily::new(2).at(time(12, 0, 0, 0));
+    assert_eq!(
+        daily.next_after(DateTime::MIN, &range),
+        Some(date(2025, 1, 1).at(12, 0, 0, 0))
+    );
+    assert_eq!(
+        daily.next_after(range.start.checked_sub(1.nanosecond()).unwrap(), &range),
+        Some(date(2025, 1, 1).at(12, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.next_after(range.start, &range),
+        Some(date(2025, 1, 1).at(12, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.next_after(date(2025, 1, 1).at(12, 0, 0, 0), &range),
+        Some(date(2025, 1, 3).at(12, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.next_after(date(2025, 1, 1).at(11, 59, 59, 999), &range),
+        Some(date(2025, 1, 1).at(12, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.next_after(range.end - 2.days(), &range),
+        Some(date(2025, 1, 31).at(12, 0, 0, 0))
+    );
+    assert_eq!(daily.next_after(range.end - 12.hours(), &range), None);
+    assert_eq!(daily.next_after(range.end, &range), None);
+    assert_eq!(daily.next_after(DateTime::MAX, &range), None);
+}
+
+#[test]
+fn daily_previous_before() {
+    let start = date(2025, 1, 1).at(0, 0, 0, 0);
+    let end = date(2025, 2, 1).at(0, 0, 0, 0);
+    let range = start..end;
+    let daily = Daily::new(2);
+    assert_eq!(daily.previous_before(DateTime::MIN, &range), None);
+    assert_eq!(daily.previous_before(range.start, &range), None);
+    assert_eq!(
+        daily.previous_before(range.start + 1.second(), &range),
+        Some(date(2025, 1, 1).at(0, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.previous_before(date(2025, 1, 1).at(0, 30, 0, 0), &range),
+        Some(date(2025, 1, 1).at(0, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.previous_before(date(2025, 1, 4).at(0, 0, 0, 0), &range),
+        Some(date(2025, 1, 3).at(0, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.previous_before(range.end, &range),
+        Some(date(2025, 1, 31).at(0, 0, 0, 0))
+    );
+}
+
+#[test]
+fn daily_at_previous_before() {
+    let start = date(2025, 1, 1).at(0, 0, 0, 0);
+    let end = date(2025, 2, 1).at(0, 0, 0, 0);
+    let range = start..end;
+    let daily = Daily::new(2).at(time(12, 0, 0, 0));
+    assert_eq!(daily.previous_before(DateTime::MIN, &range), None);
+    assert_eq!(daily.previous_before(range.start, &range), None);
+    assert_eq!(
+        daily.previous_before(range.start + 12.hours(), &range),
+        None
+    );
+    assert_eq!(
+        daily.previous_before(range.start + 12.hours().seconds(1), &range),
+        Some(date(2025, 1, 1).at(12, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.previous_before(date(2025, 1, 4).at(0, 0, 0, 0), &range),
+        Some(date(2025, 1, 3).at(12, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.previous_before(range.end, &range),
+        Some(date(2025, 1, 31).at(12, 0, 0, 0))
+    );
+}
+
+#[test]
+fn daily_closest_to() {
+    let start = date(2025, 1, 1).at(0, 0, 0, 0);
+    let end = date(2025, 2, 1).at(0, 0, 0, 0);
+    let range = start..end;
+    let daily = Daily::new(2);
+
+    assert_eq!(
+        daily.closest_to(date(2025, 1, 1).at(0, 0, 0, 0), &range),
+        Some(date(2025, 1, 1).at(0, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.closest_to(date(2025, 1, 2).at(0, 0, 0, 0), &range),
+        Some(date(2025, 1, 3).at(0, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.closest_to(
+            date(2025, 1, 2)
+                .at(0, 0, 0, 0)
+                .checked_sub(1.nanosecond())
+                .unwrap(),
+            &range,
+        ),
+        Some(date(2025, 1, 1).at(0, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.closest_to(date(2024, 12, 31).at(0, 30, 0, 0), &range),
+        Some(date(2025, 1, 1).at(0, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.closest_to(date(2025, 2, 1).at(0, 0, 0, 0), &range),
+        Some(date(2025, 1, 31).at(0, 0, 0, 0))
+    );
+
+    assert_eq!(
+        daily.closest_to(date(2025, 2, 10).at(0, 30, 0, 0), &range),
+        Some(date(2025, 1, 31).at(0, 0, 0, 0))
+    );
+}
+
+#[test]
+fn daily_closest_to_datetime_max() {
+    let start = date(2025, 1, 1).at(0, 0, 0, 0);
+    let range = start..DateTime::MAX;
+    let daily = Daily::new(2);
+
+    assert_eq!(
+        daily.closest_to(DateTime::MAX, &range),
+        Some(date(9999, 12, 30).at(0, 0, 0, 0))
+    );
+}

--- a/tests/series_test.rs
+++ b/tests/series_test.rs
@@ -6,7 +6,7 @@ use jiff::{
     civil::{DateTime, date, datetime, time},
 };
 use recurring::pattern::{daily, hourly};
-use recurring::{Event, Series};
+use recurring::{Combine, Event, Series};
 
 #[test]
 fn series_range() {
@@ -71,7 +71,9 @@ fn series_daily_at() {
     assert_eq!(
         series_take(
             start..,
-            daily(2).at(time(2, 2, 2, 2)).at(time(3, 3, 3, 3)),
+            daily(2)
+                .at(time(2, 2, 2, 2))
+                .and(daily(2).at(time(3, 3, 3, 3))),
             5
         ),
         vec![
@@ -125,7 +127,12 @@ fn series_daily_with_end_and_duration() {
 #[test]
 fn series_contains_event() {
     let start = datetime(2025, 1, 1, 1, 1, 1, 0);
-    let series = Series::new(start.., daily(2).at(time(2, 2, 2, 2)).at(time(3, 3, 3, 3)));
+    let series = Series::new(
+        start..,
+        daily(2)
+            .at(time(2, 2, 2, 2))
+            .and(daily(2).at(time(3, 3, 3, 3))),
+    );
     assert!(!series.contains_event(datetime(2025, 1, 1, 1, 1, 1, 0)));
     assert!(series.contains_event(datetime(2025, 1, 1, 2, 2, 2, 2)));
     assert!(series.contains_event(datetime(2025, 1, 1, 3, 3, 3, 3)));
@@ -139,7 +146,9 @@ fn series_relative_events() {
     let end = datetime(2025, 1, 3, 1, 1, 1, 0);
     let series = Series::new(
         start..end,
-        daily(2).at(time(2, 2, 2, 2)).at(time(3, 3, 3, 3)),
+        daily(2)
+            .at(time(2, 2, 2, 2))
+            .and(daily(2).at(time(3, 3, 3, 3))),
     );
     assert_eq!(series.get_event(datetime(2025, 1, 1, 1, 1, 1, 0)), None);
     assert_eq!(


### PR DESCRIPTION
This made the type more complex than it needs to be and since we now have the `Combine` trait, we can just use `.and()` to chain multiple `Daily`s together.