### PR TITLE
fix: don't use f64 to calculate intervals

### DIFF
--- a/src/pattern/utils.rs
+++ b/src/pattern/utils.rs
@@ -1,44 +1,176 @@
 use jiff::{Span, civil::DateTime};
 
-// Calculates the number of spans between `start` and `end`.
+/// Multiplier to increase the spans added to a given `DateTime` in bulk by the
+/// `advance_until_` functions. This was chosen arbitrarily but seems to be plenty fast for the
+/// worst case (see tests below).
+const SPAN_MULTIPLIER: i64 = 10;
+
+/// Advances `start` by `span` until the addition of another `span` would surpass `upper_bound` or
+/// cause an overflow.
+///
+/// The returned value is guaranteed to be less than or equal to `upper_bound`.
 #[inline]
-pub(super) fn spans_until(span: Span, start: DateTime, end: DateTime) -> Option<f64> {
-    let span_duration = span.to_duration(start).ok()?;
-    let duration = start.duration_until(end);
-    Some(duration.div_duration_f64(span_duration))
+pub(super) fn advance_by_until(start: DateTime, span: Span, upper_bound: DateTime) -> DateTime {
+    assert!(start <= upper_bound);
+    let (advanced, span_multiplier) = advance_by_until_fast(start, span, upper_bound);
+    advance_by_until_slow(advanced, span, span_multiplier, upper_bound)
 }
 
-/// Extension trait for floating point numbers.
-pub(super) trait FloatExt: Sized {
-    /// Returns the smallest integer greater than `self`.
-    ///
-    /// This is similar to `f64::ceil` but will yield the next larger integer if `self` already has
-    /// a zero fractional part.
-    fn ceil_strict(self) -> Self;
+// Advances `current` by adding larger growing multiples of `span` until `upper_bound`.
+//
+// Returns the last `DateTime` smaller than `upper_bound` along with the last span multiplier that
+// didn't cause an overflow.
+#[inline]
+fn advance_by_until_fast(
+    mut current: DateTime,
+    span: Span,
+    upper_bound: DateTime,
+) -> (DateTime, i64) {
+    let mut span_multiplier = SPAN_MULTIPLIER;
 
-    /// Returns the largest integer less than `self`.
-    ///
-    /// This is similar to `f64::floor` but will yield the next smaller integer if `self` already
-    /// has a zero fractional part.
-    fn floor_strict(self) -> Self;
-}
+    // This tries to add larger growing multiples of `span` until hitting the `upper_bound`,
+    // overflowing `DateTime` or overflowing the `i64` span multiplier.
+    while let Ok(span_multiple) = span.checked_mul(span_multiplier) {
+        let Ok(next) = current.checked_add(span_multiple) else {
+            // We overflowed `DateTime`.
+            return (current, span_multiplier);
+        };
 
-impl FloatExt for f64 {
-    #[inline]
-    fn ceil_strict(self) -> f64 {
-        if self.fract() == 0.0 {
-            self + 1.0
-        } else {
-            self.ceil()
+        if next > upper_bound {
+            return (current, span_multiplier);
         }
+
+        current = next;
+
+        let Some(multiplier) = span_multiplier.checked_mul(SPAN_MULTIPLIER) else {
+            // The next `span_multiplier` would overflow `i64`. We have to abort and switch to the
+            // slow path.
+            return (current, span_multiplier);
+        };
+
+        span_multiplier = multiplier;
     }
 
-    #[inline]
-    fn floor_strict(self) -> f64 {
-        if self.fract() == 0.0 {
-            self - 1.0
-        } else {
-            self.floor()
+    // `span` multiplication with `span_multiplier` overflowed. Return the previous one that
+    // didn't.
+    (current, span_multiplier / SPAN_MULTIPLIER)
+}
+
+// Advances `current` by adding multiples of `span` until `upper_bound`.
+//
+// Returns the closest span-aligned `DateTime` that's less than or equal to `upper_bound`.
+#[inline]
+fn advance_by_until_slow(
+    mut current: DateTime,
+    span: Span,
+    mut span_multiplier: i64,
+    upper_bound: DateTime,
+) -> DateTime {
+    // This adds as many large multiples of `span` as possible until hitting the `upper_bound`. It
+    // then attempts to do the same with smaller multiples of `span` until it ends up adding single
+    // spans until the bound is hit, yielding the span-aligned `DateTime` right before
+    // `upper_bound`.
+    while span_multiplier > 0 {
+        let span_multiple = span_multiplier * span;
+
+        while let Ok(next) = current.checked_add(span_multiple) {
+            if next > upper_bound {
+                break;
+            }
+
+            current = next;
         }
+
+        span_multiplier /= SPAN_MULTIPLIER;
+    }
+
+    current
+}
+
+/// Returns the closest `DateTime` to `instant` from the provided datetimes `left` and `right`.
+///
+/// If distances are equal, this will always favor `right`.
+pub(super) fn closest_to(instant: DateTime, left: DateTime, right: DateTime) -> DateTime {
+    if left.duration_until(instant).abs() < right.duration_until(instant).abs() {
+        left
+    } else {
+        right
+    }
+}
+
+/// Pick the "best" of `left` and `right`.
+///
+/// Returns either `left` or `right` if only one of them is `Some(_)`. If both are `Some` this
+/// returns the result of `f`, otherwise `None`.
+#[inline]
+pub(super) fn pick_best<F: FnOnce(DateTime, DateTime) -> DateTime>(
+    left: Option<DateTime>,
+    right: Option<DateTime>,
+    f: F,
+) -> Option<DateTime> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(f(left, right)),
+        (left, right) => left.or(right),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jiff::{ToSpan, civil::date};
+
+    #[test]
+    fn test_advance_until() {
+        assert_eq!(
+            advance_by_until(
+                date(2025, 1, 1).at(0, 0, 0, 0),
+                1.minute(),
+                date(2025, 1, 1).at(0, 0, 0, 0)
+            ),
+            date(2025, 1, 1).at(0, 0, 0, 0)
+        );
+        assert_eq!(
+            advance_by_until(
+                date(2025, 1, 1).at(0, 0, 0, 0),
+                1.minute(),
+                date(2025, 1, 10).at(1, 1, 30, 0)
+            ),
+            date(2025, 1, 10).at(1, 1, 0, 0)
+        );
+
+        assert_eq!(
+            advance_by_until(
+                date(2024, 1, 1).at(2, 2, 2, 0),
+                1.year(),
+                date(2027, 1, 10).at(1, 1, 30, 0)
+            ),
+            date(2027, 1, 1).at(2, 2, 2, 0)
+        );
+
+        assert_eq!(
+            advance_by_until(
+                date(2024, 1, 1).at(2, 2, 2, 0),
+                1.month(),
+                date(2024, 10, 10).at(1, 1, 30, 0)
+            ),
+            date(2024, 10, 1).at(2, 2, 2, 0)
+        );
+
+        assert_eq!(
+            advance_by_until(
+                date(2025, 1, 1).at(2, 2, 2, 0),
+                1.day(),
+                date(2027, 1, 3).at(2, 2, 2, 0)
+            ),
+            date(2027, 1, 3).at(2, 2, 2, 0)
+        );
+    }
+
+    #[test]
+    fn advance_until_worst_case() {
+        assert_eq!(
+            advance_by_until(DateTime::MIN, 1.nanosecond(), DateTime::MAX),
+            date(9999, 12, 31).at(23, 59, 59, 999_999_999)
+        );
     }
 }

--- a/tests/combined_test.rs
+++ b/tests/combined_test.rs
@@ -75,6 +75,10 @@ fn combined_closest_to() {
     );
     assert_eq!(
         pattern.closest_to(date(2025, 1, 2).at(8, 15, 0, 0), &range),
+        Some(date(2025, 1, 2).at(6, 0, 0, 0)),
+    );
+    assert_eq!(
+        pattern.closest_to(date(2025, 1, 2).at(8, 15, 0, 1), &range),
         Some(date(2025, 1, 2).at(10, 30, 0, 0)),
     );
     assert_eq!(

--- a/tests/daily_test.rs
+++ b/tests/daily_test.rs
@@ -32,7 +32,7 @@ fn daily_next_after() {
         daily.next_after(range.end - 1.day().nanoseconds(1), &range),
         Some(date(2025, 1, 31).at(0, 0, 0, 0))
     );
-    assert_eq!(daily.next_after(range.end - 1.day(), &range), None,);
+    assert_eq!(daily.next_after(range.end - 1.day(), &range), None);
     assert_eq!(daily.next_after(range.end, &range), None);
     assert_eq!(daily.next_after(DateTime::MAX, &range), None);
 }
@@ -151,13 +151,7 @@ fn daily_closest_to() {
     );
 
     assert_eq!(
-        daily.closest_to(
-            date(2025, 1, 2)
-                .at(0, 0, 0, 0)
-                .checked_sub(1.nanosecond())
-                .unwrap(),
-            &range,
-        ),
+        daily.closest_to(date(2025, 1, 2).at(0, 0, 0, 0) - 1.nanosecond(), &range),
         Some(date(2025, 1, 1).at(0, 0, 0, 0))
     );
 

--- a/tests/series_test.rs
+++ b/tests/series_test.rs
@@ -5,7 +5,7 @@ use jiff::{
     ToSpan,
     civil::{DateTime, date, datetime, time},
 };
-use recurring::pattern::{daily, hourly};
+use recurring::pattern::{daily, hourly, yearly};
 use recurring::{Combine, Event, Series};
 
 #[test]
@@ -338,5 +338,21 @@ fn series_event_durations() {
             .event_duration(1.year())
             .build()
             .is_err()
+    );
+}
+
+#[test]
+fn series_leap_year() {
+    let start = date(2024, 1, 1).at(0, 0, 0, 0);
+
+    assert_eq!(
+        series_take(start.., yearly(1), 5),
+        vec![
+            Event::at(date(2024, 1, 1).at(0, 0, 0, 0)),
+            Event::at(date(2025, 1, 1).at(0, 0, 0, 0)),
+            Event::at(date(2026, 1, 1).at(0, 0, 0, 0)),
+            Event::at(date(2027, 1, 1).at(0, 0, 0, 0)),
+            Event::at(date(2028, 1, 1).at(0, 0, 0, 0)),
+        ]
     );
 }


### PR DESCRIPTION
We now always add `Span`s, which ensures that we correctly deal with things like leap years and months of different length.

This also fixes a couple of bugs along the way. E.g. different logic for picking the closest datetime if there's an equal distance.