### PR TITLE
fix!: expose `series` module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 mod error;
 mod event;
 pub mod pattern;
-mod series;
+pub mod series;
 
 use core::ops::{Bound, Range, RangeBounds, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
 pub use error::Error;
@@ -16,7 +16,8 @@ pub use event::Event;
 use jiff::civil::{Date, DateTime, time};
 use jiff::{ToSpan, Zoned};
 use pattern::Combined;
-pub use series::{Iter, Series, SeriesRange, SeriesSplit, SeriesWith, SplitMode};
+#[doc(inline)]
+pub use series::{Series, SeriesRange};
 
 mod private {
     pub trait Sealed {}

--- a/src/series/mod.rs
+++ b/src/series/mod.rs
@@ -1,3 +1,4 @@
+//! A series of recurring events.
 mod iter;
 mod range;
 mod split;
@@ -483,7 +484,8 @@ where
     ///
     /// ```
     /// use jiff::{ToSpan, civil::{date, DateTime}};
-    /// use recurring::{Event, Series, SplitMode, pattern::hourly};
+    /// use recurring::{Event, Series, pattern::hourly};
+    /// use recurring::series::SplitMode;
     ///
     /// let start = date(2025, 1, 1).at(0, 0, 0, 0);
     /// let mut s1 = Series::new(start.., hourly(1));

--- a/src/series/split.rs
+++ b/src/series/split.rs
@@ -62,7 +62,8 @@ impl SeriesSplit {
     ///
     /// ```
     /// use jiff::{ToSpan, civil::{date, DateTime}};
-    /// use recurring::{Event, Series, SeriesSplit, SplitMode, pattern::hourly};
+    /// use recurring::{Event, Series, pattern::hourly};
+    /// use recurring::series::{SeriesSplit, SplitMode};
     ///
     /// let start = date(2025, 1, 1).at(0, 0, 0, 0);
     /// let mut s1 = Series::new(start.., hourly(1));


### PR DESCRIPTION
This allows to reduce the top-level items to the most important ones.

Items that usually do not need to be imported explicitly like `SeriesWith` or `Iter` are exposes via the `series` module.