### PR TITLE
refactor: split `Series` internals into `SeriesCore`

### DIFF
--- a/src/series/core.rs
+++ b/src/series/core.rs
@@ -1,0 +1,90 @@
+//! This is the core implementation of the series which does not depend on a `DateTimeRange`.
+
+use crate::{DateTimeRange, Event, Pattern};
+use jiff::{Span, civil::DateTime};
+
+#[derive(Debug, Clone)]
+pub(crate) struct SeriesCore<P> {
+    pub(crate) pattern: P,
+    pub(crate) event_duration: Span,
+}
+
+impl<P> SeriesCore<P>
+where
+    P: Pattern,
+{
+    #[inline]
+    pub(crate) fn new(pattern: P, event_duration: Span) -> SeriesCore<P> {
+        SeriesCore {
+            pattern,
+            event_duration,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn pattern(&self) -> &P {
+        &self.pattern
+    }
+
+    #[inline]
+    pub(crate) fn event_duration(&self) -> Span {
+        self.event_duration
+    }
+
+    #[inline]
+    pub(crate) fn get_event(&self, instant: DateTime, range: DateTimeRange) -> Option<Event> {
+        self.pattern
+            .closest_to(instant, range)
+            .filter(|&start| start == instant)
+            .and_then(|start| self.get_event_unchecked(start))
+    }
+
+    #[inline]
+    pub fn get_event_containing(&self, instant: DateTime, range: DateTimeRange) -> Option<Event> {
+        self.pattern
+            .closest_to(instant, range)
+            .filter(|&start| start <= instant)
+            .or_else(|| self.pattern.previous_before(instant, range))
+            .and_then(|start| self.get_event_unchecked(start))
+            .filter(|event| event.contains(instant))
+    }
+
+    #[inline]
+    pub(crate) fn get_event_after(&self, instant: DateTime, range: DateTimeRange) -> Option<Event> {
+        self.pattern
+            .next_after(instant, range)
+            .and_then(|next| self.get_event_unchecked(next))
+    }
+
+    #[inline]
+    pub(crate) fn get_event_before(
+        &self,
+        instant: DateTime,
+        range: DateTimeRange,
+    ) -> Option<Event> {
+        self.pattern
+            .previous_before(instant, range)
+            .and_then(|previous| self.get_event_unchecked(previous))
+    }
+
+    #[inline]
+    pub(crate) fn get_closest_event(
+        &self,
+        instant: DateTime,
+        range: DateTimeRange,
+    ) -> Option<Event> {
+        self.pattern
+            .closest_to(instant, range)
+            .and_then(|closest| self.get_event_unchecked(closest))
+    }
+
+    #[inline]
+    fn get_event_unchecked(&self, start: DateTime) -> Option<Event> {
+        if self.event_duration.is_positive() {
+            let end = start.checked_add(self.event_duration).ok()?;
+            Some(Event::new_unchecked(start, Some(end)))
+        } else {
+            Some(Event::at(start))
+        }
+    }
+}

--- a/src/series/split.rs
+++ b/src/series/split.rs
@@ -107,15 +107,15 @@ impl SeriesSplit {
                 }
             }
             SplitMode::NextAfter => series
-                .pattern
+                .pattern()
                 .next_after(self.instant, series.range)
                 .ok_or_else(|| err!("no series event after {}", self.instant)),
             SplitMode::PreviousBefore => series
-                .pattern
+                .pattern()
                 .previous_before(self.instant, series.range)
                 .ok_or_else(|| err!("no series event before {}", self.instant)),
             SplitMode::ClosestTo => series
-                .pattern
+                .pattern()
                 .closest_to(self.instant, series.range)
                 .ok_or_else(|| err!("no series event close to {}", self.instant)),
         }

--- a/src/series/with.rs
+++ b/src/series/with.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, err};
-use crate::series::{DateTimeRange, Series};
+use crate::series::{DateTimeRange, Series, SeriesCore};
 use crate::{IntoBounds, Pattern, try_simplify_range};
 use core::ops::{Bound, RangeBounds};
 use jiff::{Span, civil::DateTime};
@@ -36,10 +36,10 @@ where
     /// Creates a new `SeriesWith` from a `Series`.
     pub(crate) fn new(series: Series<P>) -> SeriesWith<P> {
         SeriesWith {
-            pattern: series.pattern,
+            pattern: series.core.pattern,
             bounds: series.range.into_bounds(),
             fixpoint: series.range.fixpoint,
-            event_duration: series.event_duration,
+            event_duration: series.core.event_duration,
         }
     }
 
@@ -259,9 +259,8 @@ where
         };
 
         Ok(Series {
-            pattern: self.pattern,
+            core: SeriesCore::new(self.pattern, self.event_duration),
             range,
-            event_duration: self.event_duration,
         })
     }
 }


### PR DESCRIPTION
This makes upcoming range changes a bit cleaner.