### PR TITLE
refactor!: rename `Series` methods for event lookup

### DIFF
--- a/src/series/core.rs
+++ b/src/series/core.rs
@@ -32,7 +32,7 @@ where
     }
 
     #[inline]
-    pub(crate) fn get_event(&self, instant: DateTime, range: DateTimeRange) -> Option<Event> {
+    pub(crate) fn get(&self, instant: DateTime, range: DateTimeRange) -> Option<Event> {
         self.pattern
             .closest_to(instant, range)
             .filter(|&start| start == instant)
@@ -40,7 +40,7 @@ where
     }
 
     #[inline]
-    pub fn get_event_containing(&self, instant: DateTime, range: DateTimeRange) -> Option<Event> {
+    pub fn get_containing(&self, instant: DateTime, range: DateTimeRange) -> Option<Event> {
         self.pattern
             .closest_to(instant, range)
             .filter(|&start| start <= instant)
@@ -50,14 +50,14 @@ where
     }
 
     #[inline]
-    pub(crate) fn get_event_after(&self, instant: DateTime, range: DateTimeRange) -> Option<Event> {
+    pub(crate) fn get_next_after(&self, instant: DateTime, range: DateTimeRange) -> Option<Event> {
         self.pattern
             .next_after(instant, range)
             .and_then(|next| self.get_event_unchecked(next))
     }
 
     #[inline]
-    pub(crate) fn get_event_before(
+    pub(crate) fn get_previous_before(
         &self,
         instant: DateTime,
         range: DateTimeRange,
@@ -68,11 +68,7 @@ where
     }
 
     #[inline]
-    pub(crate) fn get_closest_event(
-        &self,
-        instant: DateTime,
-        range: DateTimeRange,
-    ) -> Option<Event> {
+    pub(crate) fn get_closest_to(&self, instant: DateTime, range: DateTimeRange) -> Option<Event> {
         self.pattern
             .closest_to(instant, range)
             .and_then(|closest| self.get_event_unchecked(closest))

--- a/src/series/mod.rs
+++ b/src/series/mod.rs
@@ -281,10 +281,10 @@ where
     ///
     /// let series = Series::new(date(2025, 1, 1).at(0, 0, 0, 0).., hourly(2));
     ///
-    /// assert_eq!(series.first_event(), Some(Event::at(date(2025, 1, 1).at(0, 0, 0, 0))));
+    /// assert_eq!(series.first(), Some(Event::at(date(2025, 1, 1).at(0, 0, 0, 0))));
     /// ```
-    pub fn first_event(&self) -> Option<Event> {
-        self.get_closest_event(self.range.start)
+    pub fn first(&self) -> Option<Event> {
+        self.get_closest_to(self.range.start)
     }
 
     /// Gets the last event in the series.
@@ -303,11 +303,11 @@ where
     ///
     /// let series = Series::new(start..end, hourly(2));
     ///
-    /// assert_eq!(series.last_event(), Some(Event::at(date(2025, 12, 31).at(22, 0, 0, 0))));
+    /// assert_eq!(series.last(), Some(Event::at(date(2025, 12, 31).at(22, 0, 0, 0))));
     /// # Ok::<(), Box<dyn core::error::Error>>(())
     /// ```
-    pub fn last_event(&self) -> Option<Event> {
-        self.get_event_before(self.range.end)
+    pub fn last(&self) -> Option<Event> {
+        self.get_previous_before(self.range.end)
     }
 
     /// Returns `true` when the series contains an event starting at `instant`.
@@ -320,11 +320,11 @@ where
     ///
     /// let series = Series::new(date(2025, 1, 1).at(0, 0, 0, 0).., hourly(2));
     ///
-    /// assert!(!series.contains_event(date(2025, 1, 1).at(0, 35, 0, 0)));
-    /// assert!(series.contains_event(date(2025, 2, 10).at(12, 0, 0, 0)));
+    /// assert!(!series.contains(date(2025, 1, 1).at(0, 35, 0, 0)));
+    /// assert!(series.contains(date(2025, 2, 10).at(12, 0, 0, 0)));
     /// ```
-    pub fn contains_event(&self, instant: DateTime) -> bool {
-        self.get_event(instant).is_some()
+    pub fn contains(&self, instant: DateTime) -> bool {
+        self.get(instant).is_some()
     }
 
     /// Gets an event in the series.
@@ -339,11 +339,11 @@ where
     ///
     /// let series = Series::new(date(2025, 1, 1).at(0, 0, 0, 0).., hourly(2));
     ///
-    /// assert!(series.get_event(date(2025, 1, 1).at(1, 0, 0, 0)).is_none());
-    /// assert!(series.get_event(date(2026, 12, 31).at(14, 0, 0, 0)).is_some());
+    /// assert!(series.get(date(2025, 1, 1).at(1, 0, 0, 0)).is_none());
+    /// assert!(series.get(date(2026, 12, 31).at(14, 0, 0, 0)).is_some());
     /// ```
-    pub fn get_event(&self, instant: DateTime) -> Option<Event> {
-        self.core.get_event(instant, self.range)
+    pub fn get(&self, instant: DateTime) -> Option<Event> {
+        self.core.get(instant, self.range)
     }
 
     /// Gets the event containing `instant`.
@@ -365,29 +365,29 @@ where
     ///     .build()?;
     ///
     /// assert_eq!(
-    ///     series.get_event_containing(series_start - 1.minute()),
+    ///     series.get_containing(series_start - 1.minute()),
     ///     None,
     /// );
     /// assert_eq!(
-    ///     series.get_event_containing(series_start),
+    ///     series.get_containing(series_start),
     ///     Some(Event::new(series_start, series_start + 30.minutes())),
     /// );
     /// assert_eq!(
-    ///     series.get_event_containing(series_start + 31.minutes()),
+    ///     series.get_containing(series_start + 31.minutes()),
     ///     None,
     /// );
     /// assert_eq!(
-    ///     series.get_event_containing(series_start + 1.hour().minutes(20)),
+    ///     series.get_containing(series_start + 1.hour().minutes(20)),
     ///     Some(Event::new(series_start + 1.hour(), series_start + 1.hour().minutes(30))),
     /// );
     /// assert_eq!(
-    ///     series.get_event_containing(series_end),
+    ///     series.get_containing(series_end),
     ///     None,
     /// );
     /// # Ok::<(), Box<dyn core::error::Error>>(())
     /// ```
-    pub fn get_event_containing(&self, instant: DateTime) -> Option<Event> {
-        self.core.get_event_containing(instant, self.range)
+    pub fn get_containing(&self, instant: DateTime) -> Option<Event> {
+        self.core.get_containing(instant, self.range)
     }
 
     /// Gets the next event after `instant`.
@@ -406,33 +406,33 @@ where
     /// let series = Series::new(series_start..series_end, hourly(1));
     ///
     /// assert_eq!(
-    ///     series.get_event_after(series_start - 1.minute()),
+    ///     series.get_next_after(series_start - 1.minute()),
     ///     Some(Event::at(series_start)),
     /// );
     /// assert_eq!(
-    ///     series.get_event_after(series_start),
+    ///     series.get_next_after(series_start),
     ///     Some(Event::at(series_start + 1.hour())),
     /// );
     /// assert_eq!(
-    ///     series.get_event_after(series_start + 1.minute()),
+    ///     series.get_next_after(series_start + 1.minute()),
     ///     Some(Event::at(series_start + 1.hour())),
     /// );
     /// assert_eq!(
-    ///     series.get_event_after(series_end - 1.hour().minutes(1)),
+    ///     series.get_next_after(series_end - 1.hour().minutes(1)),
     ///     Some(Event::at(series_end - 1.hour())),
     /// );
     /// assert_eq!(
-    ///     series.get_event_after(series_end - 1.hour()),
+    ///     series.get_next_after(series_end - 1.hour()),
     ///     None,
     /// );
     /// assert_eq!(
-    ///     series.get_event_after(series_end),
+    ///     series.get_next_after(series_end),
     ///     None,
     /// );
     /// # Ok::<(), Box<dyn core::error::Error>>(())
     /// ```
-    pub fn get_event_after(&self, instant: DateTime) -> Option<Event> {
-        self.core.get_event_after(instant, self.range)
+    pub fn get_next_after(&self, instant: DateTime) -> Option<Event> {
+        self.core.get_next_after(instant, self.range)
     }
 
     /// Gets the previous event before `instant`.
@@ -448,27 +448,27 @@ where
     /// let series_start = date(2025, 1, 1).at(0, 0, 0, 0);
     /// let series = Series::new(series_start.., hourly(1));
     ///
-    /// assert_eq!(series.get_event_before(series_start), None);
-    /// assert_eq!(series.get_event_before(series_start - 1.minute()), None);
+    /// assert_eq!(series.get_previous_before(series_start), None);
+    /// assert_eq!(series.get_previous_before(series_start - 1.minute()), None);
     /// assert_eq!(
-    ///     series.get_event_before(series_start + 29.minute()),
+    ///     series.get_previous_before(series_start + 29.minute()),
     ///     Some(Event::at(series_start)),
     /// );
     /// assert_eq!(
-    ///     series.get_event_before(series_start + 1.hour()),
+    ///     series.get_previous_before(series_start + 1.hour()),
     ///     Some(Event::at(series_start)),
     /// );
     /// assert_eq!(
-    ///     series.get_event_before(series_start + 1.hour().seconds(1)),
+    ///     series.get_previous_before(series_start + 1.hour().seconds(1)),
     ///     Some(Event::at(series_start + 1.hour())),
     /// );
     /// assert_eq!(
-    ///     series.get_event_before(DateTime::MAX),
+    ///     series.get_previous_before(DateTime::MAX),
     ///     Some(Event::at(date(9999, 12, 31).at(23, 0, 0, 0))),
     /// );
     /// ```
-    pub fn get_event_before(&self, instant: DateTime) -> Option<Event> {
-        self.core.get_event_before(instant, self.range)
+    pub fn get_previous_before(&self, instant: DateTime) -> Option<Event> {
+        self.core.get_previous_before(instant, self.range)
     }
 
     /// Gets the series event with the start time closest to `instant`.
@@ -485,24 +485,24 @@ where
     /// let series = Series::new(series_start.., hourly(1));
     ///
     /// assert_eq!(
-    ///     series.get_closest_event(series_start),
+    ///     series.get_closest_to(series_start),
     ///     Some(Event::at(series_start)),
     /// );
     /// assert_eq!(
-    ///     series.get_closest_event(series_start - 1.minute()),
+    ///     series.get_closest_to(series_start - 1.minute()),
     ///     Some(Event::at(series_start)),
     /// );
     /// assert_eq!(
-    ///     series.get_closest_event(series_start + 29.minutes()),
+    ///     series.get_closest_to(series_start + 29.minutes()),
     ///     Some(Event::at(series_start)),
     /// );
     /// assert_eq!(
-    ///     series.get_closest_event(series_start + 30.minutes()),
+    ///     series.get_closest_to(series_start + 30.minutes()),
     ///     Some(Event::at(series_start + 1.hour())),
     /// );
     /// ```
-    pub fn get_closest_event(&self, instant: DateTime) -> Option<Event> {
-        self.core.get_closest_event(instant, self.range)
+    pub fn get_closest_to(&self, instant: DateTime) -> Option<Event> {
+        self.core.get_closest_to(instant, self.range)
     }
 
     /// Splits off a part of the series.
@@ -539,7 +539,7 @@ where
     ///
     /// let s2 = s1.split_off(cutoff_point)?;
     ///
-    /// assert_eq!(s2.first_event(), Some(Event::at(date(2025, 4, 1).at(13, 0, 0, 0))));
+    /// assert_eq!(s2.first(), Some(Event::at(date(2025, 4, 1).at(13, 0, 0, 0))));
     /// assert_eq!(s1.end(), cutoff_point);
     /// # Ok::<(), Box<dyn core::error::Error>>(())
     /// ```
@@ -559,7 +559,7 @@ where
     /// // Use `SplitMode::NextAfter` to split at the next event after `instant`.
     /// let s2 = s1.split_off((SplitMode::NextAfter, instant))?;
     ///
-    /// assert_eq!(s2.first_event(), Some(Event::at(date(2025, 4, 1).at(13, 0, 0, 0))));
+    /// assert_eq!(s2.first(), Some(Event::at(date(2025, 4, 1).at(13, 0, 0, 0))));
     /// assert_eq!(s1.end(), date(2025, 4, 1).at(13, 0, 0, 0));
     /// # Ok::<(), Box<dyn core::error::Error>>(())
     /// ```

--- a/src/series/range.rs
+++ b/src/series/range.rs
@@ -37,9 +37,9 @@ where
         let cursor = self.cursor_front.take()?;
         let event = if self.first {
             self.first = false;
-            self.core.get_closest_event(cursor, self.range)?
+            self.core.get_closest_to(cursor, self.range)?
         } else {
-            self.core.get_event_after(cursor, self.range)?
+            self.core.get_next_after(cursor, self.range)?
         };
 
         self.cursor_front = Some(event.start());
@@ -53,7 +53,7 @@ where
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         let cursor = self.cursor_back.take()?;
-        let event = self.core.get_event_before(cursor, self.range)?;
+        let event = self.core.get_previous_before(cursor, self.range)?;
         self.cursor_back = Some(event.start());
         Some(event)
     }

--- a/src/series/with.rs
+++ b/src/series/with.rs
@@ -148,7 +148,7 @@ where
     ///     .fixpoint(fixpoint)
     ///     .build()?;
     ///
-    /// assert_eq!(series.first_event(), Some(Event::at(date(2025, 1, 1).at(12, 34, 56, 0))));
+    /// assert_eq!(series.first(), Some(Event::at(date(2025, 1, 1).at(12, 34, 56, 0))));
     ///
     /// // Fixpoint must be less or equal to `start`.
     /// assert!(series.with().fixpoint(start).build().is_ok());

--- a/tests/series_test.rs
+++ b/tests/series_test.rs
@@ -126,7 +126,7 @@ fn series_daily_with_end_and_duration() {
 }
 
 #[test]
-fn series_contains_event() {
+fn series_contains() {
     let start = datetime(2025, 1, 1, 1, 1, 1, 0);
     let series = Series::new(
         start..,
@@ -134,11 +134,11 @@ fn series_contains_event() {
             .at(time(2, 2, 2, 2))
             .and(daily(2).at(time(3, 3, 3, 3))),
     );
-    assert!(!series.contains_event(datetime(2025, 1, 1, 1, 1, 1, 0)));
-    assert!(series.contains_event(datetime(2025, 1, 1, 2, 2, 2, 2)));
-    assert!(series.contains_event(datetime(2025, 1, 1, 3, 3, 3, 3)));
-    assert!(!series.contains_event(datetime(2025, 1, 1, 2, 2, 2, 3)));
-    assert!(!series.contains_event(datetime(2025, 1, 1, 3, 3, 3, 2)));
+    assert!(!series.contains(datetime(2025, 1, 1, 1, 1, 1, 0)));
+    assert!(series.contains(datetime(2025, 1, 1, 2, 2, 2, 2)));
+    assert!(series.contains(datetime(2025, 1, 1, 3, 3, 3, 3)));
+    assert!(!series.contains(datetime(2025, 1, 1, 2, 2, 2, 3)));
+    assert!(!series.contains(datetime(2025, 1, 1, 3, 3, 3, 2)));
 }
 
 #[test]
@@ -151,43 +151,43 @@ fn series_relative_events() {
             .at(time(2, 2, 2, 2))
             .and(daily(2).at(time(3, 3, 3, 3))),
     );
-    assert_eq!(series.get_event(datetime(2025, 1, 1, 1, 1, 1, 0)), None);
+    assert_eq!(series.get(datetime(2025, 1, 1, 1, 1, 1, 0)), None);
     assert_eq!(
-        series.get_event(datetime(2025, 1, 1, 2, 2, 2, 2)),
+        series.get(datetime(2025, 1, 1, 2, 2, 2, 2)),
         Some(Event::at(datetime(2025, 1, 1, 2, 2, 2, 2)))
     );
 
     assert_eq!(
-        series.get_event_after(datetime(2025, 1, 1, 2, 2, 2, 2)),
+        series.get_next_after(datetime(2025, 1, 1, 2, 2, 2, 2)),
         Some(Event::at(datetime(2025, 1, 1, 3, 3, 3, 3)))
     );
 
     assert_eq!(
-        series.get_event_before(datetime(2025, 1, 1, 2, 2, 2, 2)),
+        series.get_previous_before(datetime(2025, 1, 1, 2, 2, 2, 2)),
         None
     );
 
     assert_eq!(
-        series.get_event_before(datetime(2025, 1, 1, 3, 3, 3, 3)),
+        series.get_previous_before(datetime(2025, 1, 1, 3, 3, 3, 3)),
         Some(Event::at(datetime(2025, 1, 1, 2, 2, 2, 2))),
     );
 }
 
 #[test]
-fn series_get_event_containing() {
+fn series_get_containing() {
     let start = datetime(2025, 1, 1, 1, 1, 1, 0);
     let end = datetime(2025, 1, 3, 1, 1, 1, 0);
     let series = Series::new(start..end, daily(2).at(time(2, 2, 2, 2)));
     assert_eq!(
-        series.get_event_containing(datetime(2025, 1, 1, 1, 1, 1, 0)),
+        series.get_containing(datetime(2025, 1, 1, 1, 1, 1, 0)),
         None
     );
     assert_eq!(
-        series.get_event_containing(datetime(2025, 1, 1, 2, 2, 2, 2)),
+        series.get_containing(datetime(2025, 1, 1, 2, 2, 2, 2)),
         Some(Event::at(datetime(2025, 1, 1, 2, 2, 2, 2)))
     );
     assert_eq!(
-        series.get_event_containing(datetime(2025, 1, 1, 2, 2, 2, 3)),
+        series.get_containing(datetime(2025, 1, 1, 2, 2, 2, 3)),
         None
     );
 
@@ -198,7 +198,7 @@ fn series_get_event_containing() {
         .unwrap();
 
     assert_eq!(
-        series.get_event_containing(datetime(2025, 1, 1, 2, 2, 2, 3)),
+        series.get_containing(datetime(2025, 1, 1, 2, 2, 2, 3)),
         Some(Event::new(
             datetime(2025, 1, 1, 2, 2, 2, 2),
             datetime(2025, 1, 1, 3, 2, 2, 2)
@@ -206,7 +206,7 @@ fn series_get_event_containing() {
     );
 
     assert_eq!(
-        series.get_event_containing(datetime(2025, 1, 1, 3, 2, 2, 1)),
+        series.get_containing(datetime(2025, 1, 1, 3, 2, 2, 1)),
         Some(Event::new(
             datetime(2025, 1, 1, 2, 2, 2, 2),
             datetime(2025, 1, 1, 3, 2, 2, 2)
@@ -214,82 +214,82 @@ fn series_get_event_containing() {
     );
 
     assert_eq!(
-        series.get_event_containing(datetime(2025, 1, 1, 3, 2, 2, 2)),
+        series.get_containing(datetime(2025, 1, 1, 3, 2, 2, 2)),
         None
     );
 }
 
 #[test]
-fn series_first_event() {
+fn series_first() {
     let start = datetime(2025, 1, 1, 1, 1, 1, 0);
     let end = datetime(2025, 1, 3, 1, 1, 1, 0);
     let series = Series::new(start..end, daily(2).at(time(2, 2, 2, 2)));
     assert_eq!(
-        series.first_event(),
+        series.first(),
         Some(Event::at(datetime(2025, 1, 1, 2, 2, 2, 2)))
     );
 }
 
 #[test]
-fn series_last_event() {
+fn series_last() {
     let start = datetime(2025, 1, 1, 1, 1, 1, 0);
     let end = datetime(2025, 1, 10, 1, 1, 1, 0);
     let series = Series::new(start..end, daily(2).at(time(2, 2, 2, 2)));
     assert_eq!(
-        series.last_event(),
+        series.last(),
         Some(Event::at(datetime(2025, 1, 9, 2, 2, 2, 2)))
     );
 
     let series = Series::new(start.., daily(2).at(time(2, 2, 2, 2)));
     assert_eq!(
-        series.last_event(),
+        series.last(),
         Some(Event::at(datetime(9999, 12, 30, 2, 2, 2, 2)))
     );
 }
 
 #[test]
-fn series_last_event_unbounded() {
+fn series_last_unbounded() {
     let start = date(2025, 1, 1).at(1, 1, 1, 0);
     let series = Series::new(start.., hourly(2));
     assert_eq!(
-        series.last_event(),
+        series.last(),
         Some(Event::at(date(9999, 12, 31).at(23, 1, 1, 0)))
     );
 }
 
 #[test]
-fn series_get_closest_event() {
+fn series_get_closest_to() {
     let start = datetime(2025, 1, 1, 0, 0, 0, 0);
     let series = Series::new(start.., hourly(1));
 
     assert_eq!(
-        series.get_closest_event(datetime(2024, 12, 31, 0, 0, 0, 0)),
+        series.get_closest_to(datetime(2024, 12, 31, 0, 0, 0, 0)),
         Some(Event::at(datetime(2025, 1, 1, 0, 0, 0, 0)))
     );
     assert_eq!(
-        series.get_closest_event(datetime(2025, 1, 1, 0, 0, 0, 0)),
+        series.get_closest_to(datetime(2025, 1, 1, 0, 0, 0, 0)),
         Some(Event::at(datetime(2025, 1, 1, 0, 0, 0, 0)))
     );
     assert_eq!(
-        series.get_closest_event(datetime(2025, 1, 1, 0, 29, 0, 999)),
+        series.get_closest_to(datetime(2025, 1, 1, 0, 29, 0, 999)),
         Some(Event::at(datetime(2025, 1, 1, 0, 0, 0, 0)))
     );
     assert_eq!(
-        series.get_closest_event(datetime(2025, 1, 1, 0, 30, 0, 0)),
+        series.get_closest_to(datetime(2025, 1, 1, 0, 30, 0, 0)),
         Some(Event::at(datetime(2025, 1, 1, 1, 0, 0, 0)))
     );
     assert_eq!(
-        series.get_closest_event(DateTime::MIN),
+        series.get_closest_to(DateTime::MIN),
         Some(Event::at(datetime(2025, 1, 1, 0, 0, 0, 0)))
     );
     assert_eq!(
-        series.get_closest_event(DateTime::MAX),
+        series.get_closest_to(DateTime::MAX),
         Some(Event::at(datetime(9999, 12, 31, 23, 0, 0, 0)))
     );
 }
 
 #[test]
-fn series_overlapping_last_event() {
+fn series_overlapping_last() {
     let start = date(2025, 1, 1).at(0, 0, 0, 0);
     let end = date(2025, 2, 1).at(0, 0, 0, 0);
     let series = Series::new(start..end, daily(1))
@@ -300,7 +300,7 @@ fn series_overlapping_last_event() {
 
     assert_eq!(series.end(), date(2025, 1, 29).at(22, 0, 0, 0));
     assert_eq!(
-        series.last_event(),
+        series.last(),
         Some(Event::new(
             date(2025, 1, 29).at(0, 0, 0, 0),
             date(2025, 1, 31).at(2, 0, 0, 0)


### PR DESCRIPTION
Drop `event` from the methods. This makes them overall a bit shorter and more consistent with the rest of the APIs.