### PR TITLE
feat: add `Series::builder`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,9 +130,7 @@ impl ToSeries for Event {
     /// # Ok::<(), Box<dyn core::error::Error>>(())
     /// ```
     fn to_series<P: Pattern>(&self, pattern: P) -> Result<Series<P>, Error> {
-        self.start()
-            .to_series(pattern)?
-            .with()
+        Series::builder(self.start().., pattern)
             .event_duration(self.duration())
             .build()
     }

--- a/src/series/with.rs
+++ b/src/series/with.rs
@@ -33,10 +33,20 @@ impl<P> SeriesWith<P>
 where
     P: Pattern,
 {
-    /// Creates a new `SeriesWith` from a `Series`.
-    pub(crate) fn new(series: Series<P>) -> SeriesWith<P> {
+    /// Creates a new `SeriesWith` from a range and a pattern.
+    pub(crate) fn new<B: RangeBounds<DateTime>>(range: B, pattern: P) -> SeriesWith<P> {
         SeriesWith {
-            pattern: series.core.pattern,
+            pattern,
+            bounds: range.into_bounds(),
+            fixpoint: None,
+            event_duration: Span::new(),
+        }
+    }
+
+    /// Creates a new `SeriesWith` from a `Series`.
+    pub(crate) fn from_series(series: &Series<P>) -> SeriesWith<P> {
+        SeriesWith {
+            pattern: series.core.pattern.clone(),
             bounds: series.range.into_bounds(),
             fixpoint: series.range.fixpoint,
             event_duration: series.core.event_duration,


### PR DESCRIPTION
This avoid unnecessary cloning for use cases that previously required `Series::new(start.., pattern).with()` (which clones the original series).

These cases can be replaced with `Series::builder(start.., pattern)` which is more ergonomic.

This also improves `Series::with` to only clone the recurrence pattern instead of the whole original `Series` struct.